### PR TITLE
Update to fix swagger

### DIFF
--- a/Main/SpringExample/demo-spring-app-master/src/main/resources/application.properties
+++ b/Main/SpringExample/demo-spring-app-master/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 springdoc.swagger-ui.path=/swagger-ui.html
+server.forward-headers-strategy=framework
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa


### PR DESCRIPTION
Swagger is currently redirecting to the root url for its API docs, this doesn't work when behind a reverse proxy. Adding this option allows for the headers to be processed correctly.